### PR TITLE
Refactor/archive : 채팅방 보관 로직 변경

### DIFF
--- a/client/src/app/routes/pages/Chat.tsx
+++ b/client/src/app/routes/pages/Chat.tsx
@@ -1,11 +1,14 @@
 import { ErrorBoundary } from "react-error-boundary";
 import { useParams } from "react-router-dom";
 import EditorContainer from "@/features/chatEditor/EditorContainer";
+import { ArchivedEditor } from "@/features/chatEditor/components";
 import ChatContainer from "@/features/chat/ChatContainer";
 import { ErrorChatPage } from "@/features/chat/components";
+import { useGetChatRoomDetail } from "@/features/chat/queries/useGetChatRoomDetail";
 
 const Chat = () => {
   const { chatRoomId = "" } = useParams<{ chatRoomId?: string }>();
+  const { data: chatRoomDetail, isLoading: isChatRoomDetailLoading } = useGetChatRoomDetail(chatRoomId);
 
   return (
     <div className="relative flex h-[calc(100vh-3rem)] w-full flex-col justify-between">
@@ -13,7 +16,11 @@ const Chat = () => {
         <div className="flex-1 overflow-hidden">
           <ChatContainer isHome={false} chatRoomId={chatRoomId} />
         </div>
-        <EditorContainer />
+        {chatRoomDetail?.data?.isArchived ? (
+          <ArchivedEditor room={chatRoomDetail.data} />
+        ) : (
+          <EditorContainer isChatRoomDetailLoading={isChatRoomDetailLoading} />
+        )}
       </ErrorBoundary>
     </div>
   );

--- a/client/src/features/chat/queries/useGetChatRoomDetail.ts
+++ b/client/src/features/chat/queries/useGetChatRoomDetail.ts
@@ -1,0 +1,16 @@
+import { useCustomQuery, queryKeys } from "@/shared/api";
+import { ChatRoomSchema, ChatRoomType } from "@/shared/types/chatRoomType";
+
+export const useGetChatRoomDetail = (chatRoomId: string) => {
+  const result = useCustomQuery<ChatRoomType>({
+    endpoint: `/room/${chatRoomId}`,
+    schema: ChatRoomSchema,
+    queryKey: queryKeys.rooms.detail(chatRoomId),
+    options: {
+      staleTime: 0,
+      enabled: !!chatRoomId,
+    },
+  });
+
+  return result;
+};

--- a/client/src/features/chatEditor/EditorContainer.tsx
+++ b/client/src/features/chatEditor/EditorContainer.tsx
@@ -1,9 +1,12 @@
 import { ChatEditorWrapper } from "@/features/chatEditor/components";
 
-const EditorContainer = () => {
+interface EditorContainerPropsType {
+  isChatRoomDetailLoading: boolean;
+}
+const EditorContainer = ({ isChatRoomDetailLoading }: EditorContainerPropsType) => {
   return (
     <section className="mx-auto mb-4 flex w-full gap-4 text-base md:max-w-[46rem] md:gap-5 lg:gap-6 xl:max-w-[50rem]">
-      <ChatEditorWrapper />
+      <ChatEditorWrapper isChatRoomDetailLoading={isChatRoomDetailLoading} />
     </section>
   );
 };

--- a/client/src/features/chatEditor/components/ArchivedEditor.tsx
+++ b/client/src/features/chatEditor/components/ArchivedEditor.tsx
@@ -1,13 +1,9 @@
-import { useQueryClient } from "@tanstack/react-query";
 import useUnarchiveChatRoom from "@/widgets/settings-modal/queries/useUnarchiveChatRoom";
 import { Button } from "@/shared/ui/button";
 import useChatRoomStore from "@/shared/stores/useChatRoomStore";
-import { queryKeys } from "@/shared/api";
-import { ApiResponseType } from "@/shared/types/apiType";
 import { ChatRoomType } from "@/shared/types/chatRoomType";
 
 const ArchivedEditor = ({ room }: { room: ChatRoomType }) => {
-  const queryClient = useQueryClient();
   const updateChatRoomArchive = useChatRoomStore((state) => state.updateChatRoomArchive);
   const unarchiveChatRoomMutation = useUnarchiveChatRoom(room.id);
 
@@ -16,16 +12,6 @@ const ArchivedEditor = ({ room }: { room: ChatRoomType }) => {
       { roomId: room.id },
       {
         onSuccess: () => {
-          queryClient.setQueryData(
-            queryKeys.rooms.detail(room.id),
-            (oldData: ApiResponseType<ChatRoomType> | undefined) => {
-              if (oldData?.data) {
-                const updatedData = { ...oldData.data, isArchived: false };
-                return { ...oldData, data: updatedData };
-              }
-              return oldData;
-            },
-          );
           updateChatRoomArchive(room.id, false);
         },
       },

--- a/client/src/features/chatEditor/components/ArchivedEditor.tsx
+++ b/client/src/features/chatEditor/components/ArchivedEditor.tsx
@@ -1,0 +1,47 @@
+import { useQueryClient } from "@tanstack/react-query";
+import useUnarchiveChatRoom from "@/widgets/settings-modal/queries/useUnarchiveChatRoom";
+import { Button } from "@/shared/ui/button";
+import useChatRoomStore from "@/shared/stores/useChatRoomStore";
+import { queryKeys } from "@/shared/api";
+import { ApiResponseType } from "@/shared/types/apiType";
+import { ChatRoomType } from "@/shared/types/chatRoomType";
+
+const ArchivedEditor = ({ room }: { room: ChatRoomType }) => {
+  const queryClient = useQueryClient();
+  const updateChatRoomArchive = useChatRoomStore((state) => state.updateChatRoomArchive);
+  const unarchiveChatRoomMutation = useUnarchiveChatRoom(room.id);
+
+  const handleUnarchive = () => {
+    unarchiveChatRoomMutation.mutate(
+      { roomId: room.id },
+      {
+        onSuccess: () => {
+          queryClient.setQueryData(
+            queryKeys.rooms.detail(room.id),
+            (oldData: ApiResponseType<ChatRoomType> | undefined) => {
+              if (oldData?.data) {
+                const updatedData = { ...oldData.data, isArchived: false };
+                return { ...oldData, data: updatedData };
+              }
+              return oldData;
+            },
+          );
+          updateChatRoomArchive(room.id, false);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="mb-10 flex h-28 flex-col items-center justify-center gap-5">
+      <p className="text-muted-foreground text-center text-sm">
+        해당 채팅방은 보관되었습니다. 채팅을 진행하려면 먼저 보관을 취소하세요.
+      </p>
+      <Button variant="outline" disabled={unarchiveChatRoomMutation.isPending} onClick={handleUnarchive}>
+        보관 취소
+      </Button>
+    </div>
+  );
+};
+
+export default ArchivedEditor;

--- a/client/src/features/chatEditor/components/ChatEditorWrapper.tsx
+++ b/client/src/features/chatEditor/components/ChatEditorWrapper.tsx
@@ -9,7 +9,10 @@ import {
 import { useMessageSubmit } from "@/features/chatEditor/hooks/useMessageSubmit";
 import { TiptapEditorRef } from "@/features/chatEditor/types/TiptapEditorType";
 
-const ChatEditorWrapper = () => {
+interface ChatEditorWrapperPropsType {
+  isChatRoomDetailLoading: boolean;
+}
+const ChatEditorWrapper = ({ isChatRoomDetailLoading }: ChatEditorWrapperPropsType) => {
   const editorRef = useRef<TiptapEditorRef | null>(null);
   const { chatRoomId = "" } = useParams<{ chatRoomId?: string }>();
   const [hasValidContent, setHasValidContent] = useState(false);
@@ -44,7 +47,7 @@ const ChatEditorWrapper = () => {
         <ChatSendButton
           chatRoomId={chatRoomId}
           hasValidContent={hasValidContent}
-          isPending={isPending}
+          isPending={isPending || isChatRoomDetailLoading}
           onSubmit={handleSubmit}
         />
       </div>

--- a/client/src/features/chatEditor/components/index.ts
+++ b/client/src/features/chatEditor/components/index.ts
@@ -6,6 +6,7 @@ import ChatOptionButtonContainer from "./ChatOptionButtonContainer";
 import ImageUploadButton from "./ImageUploadButton";
 import ImageContainer from "./ImageContainer";
 import ImageItem from "./ImageItem";
+import ArchivedEditor from "./ArchivedEditor";
 
 export {
   CodeBlockComponent,
@@ -16,4 +17,5 @@ export {
   ImageUploadButton,
   ImageContainer,
   ImageItem,
+  ArchivedEditor,
 };

--- a/client/src/shared/api/useApiQuery.ts
+++ b/client/src/shared/api/useApiQuery.ts
@@ -138,14 +138,24 @@ export function useCustomMutation<TRes = undefined, TReq = undefined, TParams = 
       if (showToastOnSuccess && data.message) {
         toast.success(data.message);
       }
-      // 쿼리 키 초기화 - 캐시는 유지하고 데이터만 초기화 (추가 및 업데이트) (queryKeyToInvalidate가 있을 때)
-      if (queryKeyToInvalidate) {
-        queryClient.invalidateQueries({ queryKey: queryKeyToInvalidate });
-      }
-      // 쿼리 키 제거 - 캐시도 제거 (삭제) (queryKeyToRemove가 있을 때)
-      if (queryKeyToRemove) {
-        queryClient.removeQueries({ queryKey: queryKeyToRemove });
-      }
+
+      // 쿼리 키 배열 처리 함수 (단일/다중 모두 지원)
+      const processQueryKeys = (keys: string[] | string[][] | undefined, action: "invalidate" | "remove") => {
+        if (!keys) return;
+        const keyArray: string[][] = Array.isArray(keys[0]) ? (keys as string[][]) : [keys as string[]];
+        keyArray.forEach((key) => {
+          if (action === "invalidate") {
+            queryClient.invalidateQueries({ queryKey: key });
+          } else {
+            queryClient.removeQueries({ queryKey: key });
+          }
+        });
+      };
+
+      // 무효화 및 제거 처리
+      processQueryKeys(queryKeyToInvalidate, "invalidate");
+      processQueryKeys(queryKeyToRemove, "remove");
+
       // 사용자가 options로 전달한 onSuccess가 있으면 실행
       if (options.onSuccess) {
         options.onSuccess(data, variables, context);

--- a/client/src/shared/stores/useChatRoomStore.ts
+++ b/client/src/shared/stores/useChatRoomStore.ts
@@ -7,8 +7,11 @@ type useChatRoomStoreType = {
   addChatRooms: (rooms: ChatRoomType[]) => void;
   addChatRoom: (room: ChatRoomType) => void;
   updateChatRoomTitle: (roomId: string, newTitle: string) => void;
+  updateChatRoomArchive: (roomId: string, isArchived: boolean) => void;
+  updateAllChatRoomArchive: (isArchived: boolean) => void;
   deleteChatRoom: (roomId: string) => void;
   deleteAllChatRooms: () => void;
+  syncChatRooms: (rooms: ChatRoomType[]) => void;
 };
 
 // 채팅방 관리 스토어 생성
@@ -51,6 +54,22 @@ const useChatRoomStore = create<useChatRoomStoreType>((set) => ({
     });
   },
 
+  // 채팅방 보관 여부 업데이트
+  updateChatRoomArchive: (roomId, isArchived) => {
+    set((state) => {
+      const updatedRooms = state.chatRooms.map((room) => (room.id === roomId ? { ...room, isArchived } : room));
+      return { chatRooms: updatedRooms };
+    });
+  },
+
+  // 모든 채팅방 보관 여부 업데이트
+  updateAllChatRoomArchive: (isArchived) => {
+    set((state) => {
+      const updatedRooms = state.chatRooms.map((room) => ({ ...room, isArchived }));
+      return { chatRooms: updatedRooms };
+    });
+  },
+
   // 채팅방 삭제
   deleteChatRoom: (roomId) => {
     set((state) => ({
@@ -61,6 +80,38 @@ const useChatRoomStore = create<useChatRoomStoreType>((set) => ({
   // 모든 채팅방 삭제
   deleteAllChatRooms: () => {
     set({ chatRooms: [] });
+  },
+
+  // 서버 데이터와 스토어 동기화 (차이점만 반영)
+  syncChatRooms: (rooms) => {
+    set((state) => {
+      if (rooms.length === 0) return state;
+
+      let hasChanges = false;
+      const roomMap: Record<string, ChatRoomType> = {};
+      state.chatRooms.forEach((room) => {
+        roomMap[room.id] = room;
+      });
+
+      rooms.forEach((room) => {
+        const existing = roomMap[room.id];
+        if (!existing) {
+          hasChanges = true;
+          roomMap[room.id] = room;
+        } else if (existing.isArchived !== room.isArchived || existing.title !== room.title) {
+          hasChanges = true;
+          roomMap[room.id] = { ...existing, ...room };
+        }
+      });
+
+      if (!hasChanges) return state;
+
+      const newRooms = Object.values(roomMap).sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+
+      return { chatRooms: newRooms };
+    });
   },
 }));
 

--- a/client/src/shared/types/apiType.ts
+++ b/client/src/shared/types/apiType.ts
@@ -37,8 +37,18 @@ export type UseCustomMutationType<TRes = undefined, TReq = undefined, TParams = 
   paramsSchema?: z.ZodType<TParams>;
   errorOptions?: ErrorHandlingOptions;
   showToastOnSuccess?: boolean;
-  queryKeyToInvalidate?: string[];
-  queryKeyToRemove?: string[];
+  /**
+   * 무효화할 쿼리 키
+   * - 단일 쿼리 키: string[]
+   * - 여러 쿼리 키: string[][]
+   */
+  queryKeyToInvalidate?: string[] | string[][];
+  /**
+   * 제거할 쿼리 키
+   * - 단일 쿼리 키: string[]
+   * - 여러 쿼리 키: string[][]
+   */
+  queryKeyToRemove?: string[] | string[][];
   configs?: Omit<AxiosRequestConfig, "method" | "data">;
   options?: Omit<
     UseMutationOptions<ApiResponseType<TRes>, ApiError, { data?: TReq; params?: TParams } | TReq | undefined>,

--- a/client/src/widgets/layout/sidebar/components/ChatRoomList.tsx
+++ b/client/src/widgets/layout/sidebar/components/ChatRoomList.tsx
@@ -37,7 +37,7 @@ const ChatRoomList = () => {
 
   return (
     <>
-      <ChatRoomGroup chatRooms={chatRooms} />
+      <ChatRoomGroup chatRooms={chatRooms.filter((room) => !room.isArchived)} />
       {(hasMoreData || isLoadingMore) && <ChatRoomLoader loaderRef={loaderRef} />}
     </>
   );

--- a/client/src/widgets/layout/sidebar/components/menu-buttons/ChatRoomItemArchiveButton.tsx
+++ b/client/src/widgets/layout/sidebar/components/menu-buttons/ChatRoomItemArchiveButton.tsx
@@ -11,7 +11,7 @@ interface ChatRoomItemArchiveButtonPropsType {
 
 const ChatRoomItemArchiveButton = ({ roomId, isNowChatRoom }: ChatRoomItemArchiveButtonPropsType) => {
   const navigate = useNavigate();
-  const deleteChatRoom = useChatRoomStore((state) => state.deleteChatRoom);
+  const updateChatRoomArchive = useChatRoomStore((state) => state.updateChatRoomArchive);
   const archiveChatRoomMutation = useArchiveChatRoom();
 
   const handleArchive = () => {
@@ -19,7 +19,7 @@ const ChatRoomItemArchiveButton = ({ roomId, isNowChatRoom }: ChatRoomItemArchiv
       { roomId },
       {
         onSuccess: () => {
-          deleteChatRoom(roomId);
+          updateChatRoomArchive(roomId, true);
           if (isNowChatRoom) navigate("/");
         },
       },

--- a/client/src/widgets/layout/sidebar/queries/useGetChatRooms.ts
+++ b/client/src/widgets/layout/sidebar/queries/useGetChatRooms.ts
@@ -6,7 +6,9 @@ import { ChatRoomInfiniteSchema, ChatRoomInfiniteType } from "@/shared/types/cha
 import { DisplayType } from "@/shared/types/apiType";
 
 const useGetChatRooms = (type: DisplayType) => {
-  const [chatRooms, setChatRooms] = useChatRoomStore(useShallow((state) => [state.chatRooms, state.setChatRooms]));
+  const [chatRooms, setChatRooms, syncChatRooms] = useChatRoomStore(
+    useShallow((state) => [state.chatRooms, state.setChatRooms, state.syncChatRooms]),
+  );
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading, isError, refetch } =
     useCustomInfiniteQuery<ChatRoomInfiniteType>({
@@ -20,10 +22,11 @@ const useGetChatRooms = (type: DisplayType) => {
   const flatData = useMemo(() => data?.pages.flatMap((page) => page.data?.items || []) || [], [data]);
 
   useEffect(() => {
-    if (flatData.length > 0 && chatRooms.length === 0) {
-      setChatRooms(flatData);
-    }
-  }, [flatData, chatRooms, setChatRooms]);
+    if (flatData.length === 0) return;
+
+    if (chatRooms.length === 0) setChatRooms(flatData);
+    else syncChatRooms(flatData);
+  }, [flatData, chatRooms, setChatRooms, syncChatRooms]);
 
   return {
     data: flatData,

--- a/client/src/widgets/settings-modal/components/AllArchiveChatRoomSetting.tsx
+++ b/client/src/widgets/settings-modal/components/AllArchiveChatRoomSetting.tsx
@@ -6,14 +6,14 @@ import useChatRoomStore from "@/shared/stores/useChatRoomStore";
 const AllArchiveChatRoomSetting = ({ isNowChatRoom }: { isNowChatRoom: boolean }) => {
   const navigate = useNavigate();
   const { mutate: archiveAllChatRoomMutate } = useArchiveAllChatRoom();
-  const deleteAllChatRooms = useChatRoomStore((state) => state.deleteAllChatRooms);
+  const updateAllChatRoomArchive = useChatRoomStore((state) => state.updateAllChatRoomArchive);
 
   const handleArchive = () => {
     archiveAllChatRoomMutate(
       {},
       {
         onSuccess: () => {
-          deleteAllChatRooms();
+          updateAllChatRoomArchive(true);
           if (isNowChatRoom) navigate("/");
         },
       },

--- a/client/src/widgets/settings-modal/components/archive-manage/ArchiveCancelButton.tsx
+++ b/client/src/widgets/settings-modal/components/archive-manage/ArchiveCancelButton.tsx
@@ -10,22 +10,15 @@ import { ArchiveX } from "lucide-react";
 
 const ArchiveCancelButton = ({ room }: { room: ChatRoomType }) => {
   const queryClient = useQueryClient();
-  const addChatRoom = useChatRoomStore((state) => state.addChatRoom);
-  const unArchiveChatRoomMutation = useUnarchiveChatRoom();
+  const updateChatRoomArchive = useChatRoomStore((state) => state.updateChatRoomArchive);
+  const unArchiveChatRoomMutation = useUnarchiveChatRoom(room.id);
 
   const handleDelete = () => {
     unArchiveChatRoomMutation.mutate(
       { roomId: room.id },
       {
         onSuccess: () => {
-          // 사이드바 스토어에 채팅방 추가
-          addChatRoom({
-            id: room.id,
-            title: room.title,
-            isArchived: false,
-            createdAt: room.createdAt,
-            updatedAt: room.updatedAt,
-          });
+          updateChatRoomArchive(room.id, false);
           removeItemFromInfiniteCache<ChatRoomType>(queryClient, queryKeys.rooms.archived(), room.id);
         },
       },

--- a/client/src/widgets/settings-modal/queries/useUnarchiveChatRoom.ts
+++ b/client/src/widgets/settings-modal/queries/useUnarchiveChatRoom.ts
@@ -1,13 +1,13 @@
-import { queryKeys, useCustomMutation } from "@/shared/api";
+import { useCustomMutation } from "@/shared/api";
 import { ChatRoomIdRequestSchema, ChatRoomIdRequestType } from "@/shared/types/chatRoomType";
+import { queryKeys } from "@/shared/api";
 
 const useUnarchiveChatRoom = (roomId: string) => {
   return useCustomMutation<undefined, ChatRoomIdRequestType>({
     endpoint: `/room/unarchive-room`,
     method: "PATCH",
     requestSchema: ChatRoomIdRequestSchema,
-    queryKeyToRemove: queryKeys.rooms.list(),
-    queryKeyToInvalidate: queryKeys.rooms.detail(roomId),
+    queryKeyToInvalidate: [queryKeys.rooms.detail(roomId), queryKeys.rooms.list()],
   });
 };
 

--- a/client/src/widgets/settings-modal/queries/useUnarchiveChatRoom.ts
+++ b/client/src/widgets/settings-modal/queries/useUnarchiveChatRoom.ts
@@ -1,12 +1,13 @@
 import { queryKeys, useCustomMutation } from "@/shared/api";
 import { ChatRoomIdRequestSchema, ChatRoomIdRequestType } from "@/shared/types/chatRoomType";
 
-const useUnarchiveChatRoom = () => {
+const useUnarchiveChatRoom = (roomId: string) => {
   return useCustomMutation<undefined, ChatRoomIdRequestType>({
     endpoint: `/room/unarchive-room`,
     method: "PATCH",
     requestSchema: ChatRoomIdRequestSchema,
     queryKeyToRemove: queryKeys.rooms.list(),
+    queryKeyToInvalidate: queryKeys.rooms.detail(roomId),
   });
 };
 

--- a/server/app/api/endpoints/room.py
+++ b/server/app/api/endpoints/room.py
@@ -106,6 +106,15 @@ async def get_archived_rooms(page: int = 1, limit: int = 10, db: Session = Depen
 
   return JSONResponse(content=create_response(True, "보관된 채팅방 전체 조회", response), status_code=200)
 
+@router.get("/room/{room_id}")
+@handle_exceptions
+async def get_room(room_id: str, db: Session = Depends(get_db)):
+  """채팅방 조회"""
+  logger.info(f"📩 클라이언트 채팅방 조회: {room_id}")
+  response = await RoomService.get_room_service(db, room_id)
+
+  return JSONResponse(content=create_response(True, "채팅방 조회", response), status_code=200)
+
 @router.delete("/room/delete-room/")
 @handle_exceptions
 async def delete_room_no_id():

--- a/server/app/db/crud/room.py
+++ b/server/app/db/crud/room.py
@@ -47,6 +47,11 @@ class RoomCrud:
     }
 
   @staticmethod
+  def get_room(db: Session, room_id: str):
+    """채팅방 조회"""
+    return db.query(Room).filter(Room.id == room_id).first()
+
+  @staticmethod
   def get_rooms(db: Session, page: int, limit: int):
     """채팅방 목록 조회(페이지네이션) - 보관되지 않은 채팅방만"""
     return RoomCrud._get_rooms_by_archive_status(db, page, limit, is_archived=False)

--- a/server/app/services/room.py
+++ b/server/app/services/room.py
@@ -42,16 +42,24 @@ class RoomService:
     """채팅방 목록 조회"""
     result = RoomCrud.get_rooms(db, page, limit)
     return {
-      "items": [RoomResponse.model_validate(room).model_dump() for room in result["items"]],
+      "items": [RoomResponse.model_validate(room).model_dump() for room in result["items"] if room is not None],
       "meta": result["meta"]
     }
+
+  @staticmethod
+  async def get_room_service(db: Session, room_id: str) -> RoomResponse:
+    """채팅방 조회"""
+    room = RoomCrud.get_room(db, room_id)
+    if room is None:
+      raise ValueError("채팅방을 찾을 수 없습니다.")
+    return RoomResponse.model_validate(room).model_dump()
 
   @staticmethod
   async def get_archived_rooms_service(db: Session, page: int, limit: int) -> RoomListResponse:
     """보관된 채팅방 목록 조회"""
     result = RoomCrud.get_archived_rooms(db, page, limit)
     return {
-      "items": [RoomResponse.model_validate(room).model_dump() for room in result["items"]],
+      "items": [RoomResponse.model_validate(room).model_dump() for room in result["items"] if room is not None],
       "meta": result["meta"]
     }
   


### PR DESCRIPTION
- 채팅방 스토어 보관 및 취소 로직 추가

- 보관된 채팅방 에디터 대신 안내 문구 컴포넌트 대체
- 채팅방 페이지 조회 API 구현
- useCustomMutation 쿼리 키 처리 로직 개선
  - 단일 쿼리 키에서 여러 쿼리 키도 처리 가능하게 수정
- 보관된 채팅방에서 보관 취소 시 사이드바, 에디터 추가 구현